### PR TITLE
Adding 3 retries when POST request got response: 'Connection refused'.

### DIFF
--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -27,6 +27,7 @@ function KafkaProducer(options, callback) {
     // Trying to init KafkaProducer
     var self = this;
     self.proxyHost = options.proxyHost || 'localhost';
+    self.maxRetries = options.maxRetries || 3;
     // proxyPort is must have, otherwise KafkaProducer is disabled.
     if ('proxyPort' in options) {
         self.proxyPort = options.proxyPort;
@@ -51,16 +52,21 @@ function KafkaProducer(options, callback) {
 KafkaProducer.prototype.connect = function connect(onConnect) {
     var self = this;
     if (self.init) {
-        self.restClient = new KafkaRestClient(self.proxyHost, self.proxyPort, self.proxyRefreshTime,
-                function onConnectRestClient(err) {
-                    if (!err) {
-                        self.enable = true;
-                        onConnect(err);
-                    } else {
-                        self.enable = false;
-                        onConnect(err);
-                    }
-                });
+        self.restClient = new KafkaRestClient({
+          proxyHost: self.proxyHost,
+          proxyPort: self.proxyPort,
+          refreshTime: self.proxyRefreshTime,
+          maxRetries: self.maxRetries
+      },
+      function onConnectRestClient(err) {
+        if (!err) {
+            self.enable = true;
+            onConnect(err);
+        } else {
+            self.enable = false;
+            onConnect(err);
+        }
+    });
     } else {
         onConnect(new Error('Kafka producer is not initialized.'));
     }

--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -36,18 +36,19 @@ var emptyFunction = function EmptyFunction() {
 // Initialization: takes host and port and send a GET call to get all the
 // <topic, host:port> mapping.
 // Produce: for sending request, forkafka client will send a POST call
-function KafkaRestClient(proxyHost, proxyPort, refreshTime, callback) {
+function KafkaRestClient(options, callback) {
     var self = this;
     callback = callback || emptyFunction;
     self.enable = false;
     self.connecting = false;
-    self.proxyHost = proxyHost;
+    self.proxyHost = options.proxyHost;
     self.urlToHttpClientMapping = {};
-    self.proxyPort = proxyPort;
+    self.proxyPort = options.proxyPort;
     self.requestUrl = self.proxyHost + ':' + self.proxyPort;
     self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl]);
-    self.proxyRefreshTime = refreshTime;
+    self.proxyRefreshTime = options.refreshTime;
     self.topicDiscoveryTimes = 0;
+    self.maxRetries = options.maxRetries;
 
     self.discoverTopics(function discoverTopicsCallback(err, isDone) {
         if (err || !isDone) {
@@ -128,6 +129,11 @@ KafkaRestClient.prototype.getTopicToUrlMapping = function getTopicToUrlMapping(b
 // }
 KafkaRestClient.prototype.produce = function produce(produceMessage, callback) {
     var self = this;
+    self.produceWithRetry(produceMessage, 0, callback);
+};
+
+KafkaRestClient.prototype.produceWithRetry = function produceWithRetry(produceMessage, retry, callback) {
+    var self = this;
     if (self.enable) {
         if (produceMessage.topic in self.cachedTopicToUrlMapping) {
             var pathUrl = self.cachedTopicToUrlMapping[produceMessage.topic];
@@ -149,7 +155,16 @@ KafkaRestClient.prototype.produce = function produce(produceMessage, callback) {
             };
             httpClient.post(reqOpts, produceMessage.message, function handlePostCall(err, res, body) {
                 if (err) {
-                    callback(err);
+                    // Only retry with exception: Connection refused
+                    if (err.reason === 'connect ECONNREFUSED' && retry < self.maxRetries) {
+                        /* eslint-disable no-undef,block-scoped-var */
+                        setTimeout(function delayedProduce() {
+                            self.produceWithRetry(produceMessage, retry + 1, callback);
+                        }, 600 * Math.pow(5, retry + 1)); // 3sec, 15sec, 75sec.
+                        /* eslint-enable no-undef,block-scoped-var */
+                    } else {
+                        callback(err);
+                    }
                 } else {
                     callback(null, body);
                 }
@@ -161,7 +176,7 @@ KafkaRestClient.prototype.produce = function produce(produceMessage, callback) {
     } else if (self.connecting) {
         /* eslint-disable no-undef,block-scoped-var */
         setTimeout(function waitForInitDone() {
-            self.produce(produceMessage, callback);
+            self.produceWithRetry(produceMessage, retry, callback);
         }, 100);
         /* eslint-enable no-undef,block-scoped-var */
     } else {


### PR DESCRIPTION
The reason is rest proxys are using haproxy to route the request.
If a server is died unexpectedly, and hacheck hasn't update it, then we
have a short period, haproxy will still route requests to died box,
and those data will get lost forever from client side.