### PR TITLE
Implement graceful close for KafkaRestProducer

### DIFF
--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -196,6 +196,7 @@ function _produceBatch(messageBatch, topic, timeStamp, callback) {
     var self = this;
 
     var msg = messageBatch.getBatchedMessage();
+    messageBatch.resetBatchedMessage();
     var pmsg = self.getProduceMessage(topic, msg, timeStamp, 'batch');
 
     self._produce(pmsg, onProduced);
@@ -204,8 +205,6 @@ function _produceBatch(messageBatch, topic, timeStamp, callback) {
         for (var i = 0; i < messageBatch.pendingCallbacks.length; i++) {
             messageBatch.pendingCallbacks[i](err, res);
         }
-
-        messageBatch.resetBatchedMessage();
 
         if (callback) {
             callback(err, res);

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -172,35 +172,44 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
         return self.getProduceMessage(topic, msg, timeStamp, 'batch');
     };
 
-    if (self.topicToBatchQueue[topic]) {
-        messageBatch = self.topicToBatchQueue[topic];
-        if ((messageBatch.sizeBytes + messageLength + 4) > self.maxBatchSizeBytes) {
-            self._produce(produceMessage(messageBatch.getBatchedMessage()), callback);
-
-            self.topicToBatchQueue[topic].resetBatchedMessage();
-        }
-
-        // Do not add to buffer if message is larger than max buffer size, produce directly
-        if (messageLength > self.maxBatchSizeBytes) {
-            self._produce(produceMessage(message), callback);
-        } else {
-            self.topicToBatchQueue[topic].addMessage(message, callback);
-        }
-    } else {
+    if (!self.topicToBatchQueue[topic]) {
         messageBatch = new MessageBatch(self.maxBatchSizeBytes);
-
-        // Do not add to buffer if message is larger than max buffer size, produce directly
-        if (messageLength > self.maxBatchSizeBytes) {
-            self._produce(produceMessage(message), callback);
-        } else {
-            messageBatch.addMessage(message, callback);
-        }
-
         self.topicToBatchQueue[topic] = messageBatch;
+    } else {
+        messageBatch = self.topicToBatchQueue[topic];
     }
 
-    if (callback) {
-        callback();
+    if ((messageBatch.sizeBytes + messageLength + 4) > self.maxBatchSizeBytes) {
+        self._produceBatch(messageBatch, topic, timeStamp);
+    }
+
+    // Do not add to buffer if message is larger than max buffer size, produce directly
+    if (messageLength > self.maxBatchSizeBytes) {
+        self._produce(produceMessage(message), callback);
+    } else {
+        self.topicToBatchQueue[topic].addMessage(message, callback);
+    }
+};
+
+KafkaProducer.prototype._produceBatch =
+function _produceBatch(messageBatch, topic, timeStamp, callback) {
+    var self = this;
+
+    var msg = messageBatch.getBatchedMessage();
+    var pmsg = self.getProduceMessage(topic, msg, timeStamp, 'batch');
+
+    self._produce(pmsg, onProduced);
+
+    function onProduced(err, res) {
+        for (var i = 0; i < messageBatch.pendingCallbacks.length; i++) {
+            messageBatch.pendingCallbacks[i](err, res);
+        }
+
+        messageBatch.resetBatchedMessage();
+
+        if (callback) {
+            callback(err, res);
+        }
     }
 };
 
@@ -214,15 +223,10 @@ KafkaProducer.prototype.flushEntireCache = function flushEntireCache(callback) {
         var messageBatch = self.topicToBatchQueue[topic];
 
         if (messageBatch.numMessages > 0) {
-            var timeStamp = new Date().getTime();
-            var produceMessage = self.getProduceMessage(topic,
-                messageBatch.getBatchedMessage(),
-                timeStamp,
-                'batch');
+            var timeStamp = Date.now();
             pending++;
-            self._produce(produceMessage, onProduced);
 
-            self.topicToBatchQueue[topic].resetBatchedMessage();
+            self._produceBatch(messageBatch, topic, timeStamp, onProduced);
         }
     }
 

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -24,6 +24,8 @@ var hostName = require('os').hostname();
 var KafkaRestClient = require('./kafka_rest_client');
 var MigratorBlacklistClient = require('./migrator_blacklist_client');
 var MessageBatch = require('./message_batch');
+var clearInterval = require('timers').clearInterval;
+var setInterval = require('timers').setInterval;
 
 function KafkaProducer(options, callback) { // eslint-disable-line
     // Trying to init KafkaProducer

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -79,6 +79,10 @@ function KafkaProducer(options, callback) { // eslint-disable-line
         self.init = false;
         self.enable = false;
     }
+
+    self.pendingWrites = 0;
+    self.closing = false;
+    self.closeCallback = null;
 }
 
 KafkaProducer.prototype.connect = function connect(onConnect) {
@@ -126,11 +130,17 @@ KafkaProducer.prototype.produce = function produce(topic, message, timeStamp, ca
 KafkaProducer.prototype._produce = function _produce(msg, callback) {
     var self = this;
 
+    self.pendingWrites++;
     self.restClient.produce(msg, onResponse);
 
     function onResponse(err, result) {
         if (callback) {
             callback(err, result);
+        }
+
+        self.pendingWrites--;
+        if (self.closing) {
+            self._tryClose();
         }
     }
 };
@@ -269,16 +279,31 @@ KafkaProducer.prototype.getWholeMsg = function getWholeMsg(topic, message, timeS
 
 KafkaProducer.prototype.close = function close(callback) {
     var self = this;
-    if (self.batching) {
-        self.flushEntireCache(callback);
-    }
+
     self.enable = false;
+    self.closing = false;
+    self.closeCallback = callback;
+
+    if (self.batching) {
+        self.flushEntireCache();
+    }
+
+    self._tryClose();
+};
+
+KafkaProducer.prototype._tryClose = function _tryClose() {
+    var self = this;
+
+    if (self.pendingWrites !== 0) {
+        return;
+    }
+
     if (self.restClient) {
         self.restClient.close();
     }
 
-    if (callback && !self.batching) {
-        callback();
+    if (self.closeCallback) {
+        self.closeCallback();
     }
 };
 

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -71,7 +71,7 @@ function KafkaProducer(options, callback) { // eslint-disable-line
             var flushCache = function flushCache() { // eslint-disable-line
                 self.flushEntireCache();
             };
-            setInterval(flushCache, self.flushCycleSecs * 1000); // eslint-disable-line
+            self.flushInterval = setInterval(flushCache, self.flushCycleSecs * 1000); // eslint-disable-line
         }
 
         self.init = true;
@@ -296,8 +296,12 @@ KafkaProducer.prototype.close = function close(callback) {
     var self = this;
 
     self.enable = false;
-    self.closing = false;
+    self.closing = true;
     self.closeCallback = callback;
+
+    if (self.flushInterval) {
+        clearInterval(self.flushInterval);
+    }
 
     if (self.batching) {
         self.flushEntireCache();

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -180,6 +180,7 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
 KafkaProducer.prototype.flushEntireCache = function flushEntireCache(callback) {
     var self = this;
 
+    var pending = 0;
     var keys = Object.keys(self.topicToBatchQueue);
     for (var i = 0; i < keys.length; i++) {
         var topic = keys[i];
@@ -191,9 +192,25 @@ KafkaProducer.prototype.flushEntireCache = function flushEntireCache(callback) {
                 messageBatch.getBatchedMessage(),
                 timeStamp,
                 'batch');
-            self._produce(produceMessage, callback);
+            pending++;
+            self._produce(produceMessage, onProduced);
 
             self.topicToBatchQueue[topic].resetBatchedMessage();
+        }
+    }
+
+    if (pending === 0 && callback) {
+        callback(null);
+    }
+
+    function onProduced(err) {
+        if (err && pending !== 0 && callback) {
+            pending = 0;
+            return callback(err);
+        }
+
+        if (--pending === 0 && callback) {
+            callback(null);
         }
     }
 };

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -115,6 +115,13 @@ KafkaProducer.prototype.connect = function connect(onConnect) {
 KafkaProducer.prototype.produce = function produce(topic, message, timeStamp, callback) {
     var self = this;
 
+    if (self.closing) {
+        if (callback) {
+            callback(new Error('cannot produce() to closed KafkaRestProducer'));
+        } // TODO: else { self.logger.error() }
+        return;
+    }
+
     if (self.restClient) {
         if (self.batching) {
             self.batch(topic, message, timeStamp, callback);
@@ -149,6 +156,14 @@ KafkaProducer.prototype._produce = function _produce(msg, callback) {
 // Flush topic's BatchMessage on flushCycleSecs interval or if greater than maxBatchSizeBytes
 KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callback) {
     var self = this;
+
+    if (self.closing) {
+        if (callback) {
+            callback(new Error('cannot batch() to closed KafkaRestProducer'));
+        } // TODO: else { self.logger.error() }
+        return;
+    }
+
     var messageBatch;
     var messageLength = message.length;
     var produceMessage = function produceMessage(msg) {

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -116,14 +116,22 @@ KafkaProducer.prototype.produce = function produce(topic, message, timeStamp, ca
             self.batch(topic, message, timeStamp, callback);
         } else {
             var produceMessage = self.getProduceMessage(topic, message, timeStamp, 'binary');
-            self.restClient.produce(produceMessage, function handleResponse(err, res) {
-                if (callback) {
-                    callback(err, res);
-                }
-            });
+            self._produce(produceMessage, callback);
         }
     } else if (callback) {
         callback(new Error('Kafka Rest Client is not initialized!'));
+    }
+};
+
+KafkaProducer.prototype._produce = function _produce(msg, callback) {
+    var self = this;
+
+    self.restClient.produce(msg, onResponse);
+
+    function onResponse(err, result) {
+        if (callback) {
+            callback(err, result);
+        }
     }
 };
 
@@ -140,22 +148,14 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
     if (self.topicToBatchQueue[topic]) {
         messageBatch = self.topicToBatchQueue[topic];
         if ((messageBatch.sizeBytes + messageLength + 4) > self.maxBatchSizeBytes) {
-            self.restClient.produce(produceMessage(messageBatch.getBatchedMessage()), function handleResponse(err, res) {
-                if (callback) {
-                    callback(err, res);
-                }
-            });
+            self._produce(produceMessage(messageBatch.getBatchedMessage()), callback);
 
             self.topicToBatchQueue[topic].resetBatchedMessage();
         }
 
         // Do not add to buffer if message is larger than max buffer size, produce directly
         if (messageLength > self.maxBatchSizeBytes) {
-            self.restClient.produce(produceMessage(message), function handleResponse(err, res) {
-                if (callback) {
-                    callback(err, res);
-                }
-            });
+            self._produce(produceMessage(message), callback);
         } else {
             self.topicToBatchQueue[topic].addMessage(message, callback);
         }
@@ -164,11 +164,7 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
 
         // Do not add to buffer if message is larger than max buffer size, produce directly
         if (messageLength > self.maxBatchSizeBytes) {
-            self.restClient.produce(produceMessage(message), function handleResponse(err, res) {
-                if (callback) {
-                    callback(err, res);
-                }
-            });
+            self._produce(produceMessage(message), callback);
         } else {
             messageBatch.addMessage(message, callback);
         }
@@ -184,12 +180,6 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
 KafkaProducer.prototype.flushEntireCache = function flushEntireCache(callback) {
     var self = this;
 
-    var handleResponse = function handleResponse(err, res) {
-        if (callback) {
-            callback(err, res);
-        }
-    };
-
     var keys = Object.keys(self.topicToBatchQueue);
     for (var i = 0; i < keys.length; i++) {
         var topic = keys[i];
@@ -201,7 +191,7 @@ KafkaProducer.prototype.flushEntireCache = function flushEntireCache(callback) {
                 messageBatch.getBatchedMessage(),
                 timeStamp,
                 'batch');
-            self.restClient.produce(produceMessage, handleResponse);
+            self._produce(produceMessage, callback);
 
             self.topicToBatchQueue[topic].resetBatchedMessage();
         }

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -32,6 +32,7 @@ function MessageBatch(size) {
     self.timestamp = new Date().getTime();
     self.numMessages = 0;
     self.sizeBytes = 4;
+    self.pendingCallbacks = [];
 }
 
 MessageBatch.prototype.addMessage = function addMessage(message, callback) {
@@ -63,7 +64,7 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
     self.currOffset += bytesWritten;
 
     if (callback) {
-        callback(null);
+        self.pendingCallbacks.push(callback);
     }
 };
 
@@ -83,6 +84,7 @@ MessageBatch.prototype.resetBatchedMessage = function resetBatchedMessage() {
     self.currOffset = 4;
     self.numMessages = 0;
     self.sizeBytes = 4;
+    self.pendingCallbacks.length = 0;
 };
 
 module.exports = MessageBatch;

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -48,7 +48,12 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         message.copy(self.cachedBuf, msgOffset);
         bytesWritten += message.length;
     } else {
-        callback(new Error('For batching, message must be a string or buffer!'));
+        var err = new Error('For batching, message must be a string or buffer!');
+        if (callback) {
+            callback(err);
+        } else {
+            throw err;
+        }
     }
 
     self.cachedBuf.writeInt32BE(bytesWritten - 4, offset);
@@ -56,6 +61,10 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
     self.numMessages += 1;
     self.sizeBytes += bytesWritten;
     self.currOffset += bytesWritten;
+
+    if (callback) {
+        callback(null);
+    }
 };
 
 MessageBatch.prototype.getBatchedMessage = function getBatchedMessage() {

--- a/test/test_kafka_producer.js
+++ b/test/test_kafka_producer.js
@@ -69,9 +69,9 @@ test('Kafka producer could write with produce.', function testKafkaProducer(asse
     setTimeout(function stopTest1() {
         server.stop();
         producer.close();
+        assert.end();
     }, 1000);
     /* eslint-enable no-undef,block-scoped-var */
-    assert.end();
 });
 
 test('Kafka producer could write with produce and blacklist.', function testKafkaProducer(assert) {
@@ -118,9 +118,9 @@ test('Kafka producer could write with produce and blacklist.', function testKafk
         restServer.stop();
         blacklistServer.stop();
         producer.close();
+        assert.end();
     }, 1000);
     /* eslint-enable no-undef,block-scoped-var */
-    assert.end();
 });
 
 test('Kafka producer handle unavailable proxy.', function testKafkaProducerHandleUnavailableProxy(assert) {
@@ -167,9 +167,9 @@ test('Kafka producer refresh.', function testKafkaProducerTopicRefresh(assert) {
     setTimeout(function stopTest2() {
         producer.close();
         server2.stop();
+        assert.end();
     }, 3000);
     /* eslint-enable no-undef,block-scoped-var */
-    assert.end();
 });
 
 test('Test get whole msg', function testKafkaProducerGetWholeMsgFunction(assert) {


### PR DESCRIPTION
Changes split out into many commits. Don't really feel too comfortable with
lack of tests but that can be fixed tomorrow.

 - Fix the potential double callback in flush
 - Add an _produce choke point method
 - Keep track of pendingWrites
 - Add tryClose() where we try to close after any write.

r: @bwwinthehouse @fx19880617