### PR TITLE
Blacklist topics to NOT batch

### DIFF
--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -63,6 +63,7 @@ function KafkaProducer(options, callback) { // eslint-disable-line
         } else {
             self.batching = true;
         }
+        self.batchingBlacklist = options.batchingBlacklist || [];
 
         self.enableAudit = options.enableAudit || true;
         self.auditTopicName = options.auditTopicName || 'chaperone2-audit-rest-proxy-client';
@@ -134,6 +135,11 @@ KafkaProducer.prototype.connect = function connect(onConnect) {
     }
 };
 
+// Check whether or not we should batch this topic
+KafkaProducer.prototype.shouldBatch = function shouldBatch(topic) {
+    return this.batching && this.batchingBlacklist.indexOf(topic) === -1;
+};
+
 KafkaProducer.prototype.produce = function produce(topic, message, timeStamp, callback) {
     var self = this;
 
@@ -150,7 +156,7 @@ KafkaProducer.prototype.produce = function produce(topic, message, timeStamp, ca
     }
 
     if (self.restClient) {
-        if (self.batching) {
+        if (self.shouldBatch(topic)) {
             self.batch(topic, message, timeStamp, callback);
         } else {
             var produceMessage = self.getProduceMessage(topic, message, timeStamp, 'binary');


### PR DESCRIPTION
There are certain topics that are business critical and should not be batched. The current implementation would require multiple clients. This is better than multiple clients