### PR TITLE
Fix bug around specific message sizes in a batch

### DIFF
--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -210,7 +210,6 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
     }
 
     var messageBatch;
-    var messageLength = message.length;
     var produceMessage = function produceMessage(msg) {
         return self.getProduceMessage(topic, msg, timeStamp, 'batch');
     };
@@ -222,14 +221,15 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
         messageBatch = self.topicToBatchQueue[topic];
     }
 
-    if ((messageBatch.sizeBytes + messageLength + 4) > self.maxBatchSizeBytes) {
-        self._produceBatch(messageBatch, topic, timeStamp);
-    }
-
-    // Do not add to buffer if message is larger than max buffer size, produce directly
-    if (messageLength > self.maxBatchSizeBytes) {
+    if (messageBatch.exceedsBatchSizeBytes(message)) {
+        // Do not add to buffer if message is larger than max buffer size, produce directly
         self._produce(produceMessage(message), callback);
     } else {
+        if (!messageBatch.canAddMessageToBatch(message)) {
+            // Batch is cannot accept this new message, so we should flush to kafka before we add.
+            self._produceBatch(messageBatch, topic, timeStamp);
+        }
+
         self.topicToBatchQueue[topic].addMessage(message, callback);
     }
 };

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -213,10 +213,9 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
     }
 
     if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
-        var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
         if (callback) {
-            callback(err);
-        }
+            callback(new Error('For batching, message must be a string or buffer, not ' + (typeof message)));
+        } // TODO:  else { self.logger.error(); }
         return;
     }
 
@@ -238,7 +237,7 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
     } else {
         if (!messageBatch.canAddMessageToBatch(message)) {
             // Batch is cannot accept this new message, so we should flush to kafka before we add.
-            self._produceBatch(messageBatch, topic, timeStamp);
+            self._produceBatch(messageBatch, topic, timeStamp, callback);
         }
 
         self.topicToBatchQueue[topic].addMessage(message, callback);

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -221,11 +221,11 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
         messageBatch = self.topicToBatchQueue[topic];
     }
 
-    if (messageBatch.exceedsBatchSizeBytes(message)) {
+    if (messageBatch.exceedsBatchSizeBytes(message, callback)) {
         // Do not add to buffer if message is larger than max buffer size, produce directly
         self._produce(produceMessage(message), callback);
     } else {
-        if (!messageBatch.canAddMessageToBatch(message)) {
+        if (!messageBatch.canAddMessageToBatch(message, callback)) {
             // Batch is cannot accept this new message, so we should flush to kafka before we add.
             self._produceBatch(messageBatch, topic, timeStamp);
         }

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -232,11 +232,11 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
         messageBatch = self.topicToBatchQueue[topic];
     }
 
-    if (messageBatch.exceedsBatchSizeBytes(message, callback)) {
+    if (messageBatch.exceedsBatchSizeBytes(message)) {
         // Do not add to buffer if message is larger than max buffer size, produce directly
         self._produce(produceMessage(message), callback);
     } else {
-        if (!messageBatch.canAddMessageToBatch(message, callback)) {
+        if (!messageBatch.canAddMessageToBatch(message)) {
             // Batch is cannot accept this new message, so we should flush to kafka before we add.
             self._produceBatch(messageBatch, topic, timeStamp);
         }

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -200,6 +200,8 @@ KafkaProducer.prototype._produce = function _produce(msg, callback) {
 
 // Add message to topic's BatchMessage in cache or add new topic to cache
 // Flush topic's BatchMessage on flushCycleSecs interval or if greater than maxBatchSizeBytes
+// If something other than a Buffer or string is passed as the message argument,
+// this will fail silently unless callback is provided.
 KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callback) {
     var self = this;
 
@@ -212,10 +214,9 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
 
     if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
         var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
-        if (!callback) {
-            throw err;
+        if (callback) {
+            callback(err);
         }
-        callback(err);
         return;
     }
 

--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var hostName = require('os').hostname();
 var KafkaRestClient = require('./kafka_rest_client');
 var MigratorBlacklistClient = require('./migrator_blacklist_client');
@@ -206,6 +207,15 @@ KafkaProducer.prototype.batch = function batch(topic, message, timeStamp, callba
         if (callback) {
             callback(new Error('cannot batch() to closed KafkaRestProducer'));
         } // TODO: else { self.logger.error() }
+        return;
+    }
+
+    if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
+        var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
+        if (!callback) {
+            throw err;
+        }
+        callback(err);
         return;
     }
 

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -70,10 +70,9 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         bytesWritten += message.length;
     } else {
         var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
-        if (!callback) {
-            throw err;
+        if (callback) {
+            callback(err);
         }
-        callback(err);
         return;
     }
 

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -24,23 +24,51 @@ var Buffer = require('buffer').Buffer;
 
 // The batch message payload should follow:
 // 4 BE bytes number of messages + 4 BE bytes size of message + actual message
+var KAFKA_BATCH_PADDING_BYTES = 4;
+var KAFKA_MESSAGE_PADDING_BYTES = 4;
+
 function MessageBatch(size) {
     var self = this;
 
-    self.cachedBuf = new Buffer(size);
-    self.currOffset = 4;
+    self.maxBufferSize = size;
+    self.cachedBuf = new Buffer(self.maxBufferSize);
+    self.currOffset = KAFKA_BATCH_PADDING_BYTES;
     self.timestamp = new Date().getTime();
     self.numMessages = 0;
-    self.sizeBytes = 4;
+    self.sizeBytes = KAFKA_BATCH_PADDING_BYTES;
     self.pendingCallbacks = [];
 }
+
+MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message) {
+    var self = this;
+
+    if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
+        // Not sure what this object is
+        throw new Error('For batching, message must be a string or buffer!');
+    }
+
+    // No single message can be a batch by itself unless it is smaller
+    // than our buffer size
+    return message.length + KAFKA_BATCH_PADDING_BYTES + KAFKA_MESSAGE_PADDING_BYTES > self.maxBufferSize;
+};
+
+MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message) {
+    var self = this;
+
+    if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
+        // Not sure what this object is
+        throw new Error('For batching, message must be a string or buffer, not ' + (typeof message));
+    }
+
+    return self.sizeBytes + KAFKA_MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
+};
 
 MessageBatch.prototype.addMessage = function addMessage(message, callback) {
     var self = this;
 
-    var bytesWritten = 4;
+    var bytesWritten = KAFKA_MESSAGE_PADDING_BYTES;
     var offset = self.currOffset;
-    var msgOffset = offset + 4;
+    var msgOffset = offset + KAFKA_MESSAGE_PADDING_BYTES;
 
     if (typeof message === 'string') {
         bytesWritten += self.cachedBuf.write(message, msgOffset);
@@ -49,7 +77,7 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         message.copy(self.cachedBuf, msgOffset);
         bytesWritten += message.length;
     } else {
-        var err = new Error('For batching, message must be a string or buffer!');
+        var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
         if (callback) {
             callback(err);
         } else {
@@ -57,7 +85,7 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         }
     }
 
-    self.cachedBuf.writeInt32BE(bytesWritten - 4, offset);
+    self.cachedBuf.writeInt32BE(bytesWritten - KAFKA_MESSAGE_PADDING_BYTES, offset);
 
     self.numMessages += 1;
     self.sizeBytes += bytesWritten;
@@ -73,7 +101,7 @@ MessageBatch.prototype.getBatchedMessage = function getBatchedMessage() {
 
     var currBatchedMessage = new Buffer(self.sizeBytes);
     currBatchedMessage.writeInt32BE(self.numMessages, 0);
-    self.cachedBuf.copy(currBatchedMessage, 4, 4, self.currOffset);
+    self.cachedBuf.copy(currBatchedMessage, KAFKA_BATCH_PADDING_BYTES, KAFKA_BATCH_PADDING_BYTES, self.currOffset);
 
     return currBatchedMessage;
 };
@@ -85,9 +113,9 @@ MessageBatch.prototype.getPendingCallbacks = function getPendingCallbacks() {
 MessageBatch.prototype.resetBatchedMessage = function resetBatchedMessage() {
     var self = this;
 
-    self.currOffset = 4;
+    self.currOffset = KAFKA_BATCH_PADDING_BYTES;
     self.numMessages = 0;
-    self.sizeBytes = 4;
+    self.sizeBytes = KAFKA_BATCH_PADDING_BYTES;
     self.pendingCallbacks = [];
 };
 

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -24,51 +24,65 @@ var Buffer = require('buffer').Buffer;
 
 // The batch message payload should follow:
 // 4 BE bytes number of messages + 4 BE bytes size of message + actual message
-var KAFKA_BATCH_PADDING_BYTES = 4;
-var KAFKA_MESSAGE_PADDING_BYTES = 4;
+var KAFKA_PADDINGS = {
+  MESSAGE_PADDING_BYTES: 4,
+  BATCH_PADDING_BYTES: 4
+};
+Object.freeze(KAFKA_PADDINGS);
 
 function MessageBatch(size) {
     var self = this;
 
     self.maxBufferSize = size;
     self.cachedBuf = new Buffer(self.maxBufferSize);
-    self.currOffset = KAFKA_BATCH_PADDING_BYTES;
+    self.currOffset = KAFKA_PADDINGS.BATCH_PADDING_BYTES;
     self.timestamp = new Date().getTime();
     self.numMessages = 0;
-    self.sizeBytes = KAFKA_BATCH_PADDING_BYTES;
+    self.sizeBytes = KAFKA_PADDINGS.BATCH_PADDING_BYTES;
     self.pendingCallbacks = [];
 }
 
-MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message) {
+MessageBatch.prototype._throwErrorIfNoCallback = function _throwErrorIfNoCallback(errorMessage, callback) {
+    var err = new Error(errorMessage);
+    if (!callback) {
+        throw err;
+    }
+    callback(err);
+};
+
+MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message, callback) {
     var self = this;
 
     if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
         // Not sure what this object is
-        throw new Error('For batching, message must be a string or buffer!');
+        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
+        return null;
     }
 
     // No single message can be a batch by itself unless it is smaller
     // than our buffer size
-    return message.length + KAFKA_BATCH_PADDING_BYTES + KAFKA_MESSAGE_PADDING_BYTES > self.maxBufferSize;
+    return message.length + KAFKA_PADDINGS.BATCH_PADDING_BYTES +
+        KAFKA_PADDINGS.MESSAGE_PADDING_BYTES > self.maxBufferSize;
 };
 
-MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message) {
+MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message, callback) {
     var self = this;
 
     if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
         // Not sure what this object is
-        throw new Error('For batching, message must be a string or buffer, not ' + (typeof message));
+        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
+        return null;
     }
 
-    return self.sizeBytes + KAFKA_MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
+    return self.sizeBytes + KAFKA_PADDINGS.MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
 };
 
 MessageBatch.prototype.addMessage = function addMessage(message, callback) {
     var self = this;
 
-    var bytesWritten = KAFKA_MESSAGE_PADDING_BYTES;
+    var bytesWritten = KAFKA_PADDINGS.MESSAGE_PADDING_BYTES;
     var offset = self.currOffset;
-    var msgOffset = offset + KAFKA_MESSAGE_PADDING_BYTES;
+    var msgOffset = offset + KAFKA_PADDINGS.MESSAGE_PADDING_BYTES;
 
     if (typeof message === 'string') {
         bytesWritten += self.cachedBuf.write(message, msgOffset);
@@ -77,15 +91,11 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         message.copy(self.cachedBuf, msgOffset);
         bytesWritten += message.length;
     } else {
-        var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
-        if (callback) {
-            callback(err);
-        } else {
-            throw err;
-        }
+        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
+        return;
     }
 
-    self.cachedBuf.writeInt32BE(bytesWritten - KAFKA_MESSAGE_PADDING_BYTES, offset);
+    self.cachedBuf.writeInt32BE(bytesWritten - KAFKA_PADDINGS.MESSAGE_PADDING_BYTES, offset);
 
     self.numMessages += 1;
     self.sizeBytes += bytesWritten;
@@ -101,7 +111,8 @@ MessageBatch.prototype.getBatchedMessage = function getBatchedMessage() {
 
     var currBatchedMessage = new Buffer(self.sizeBytes);
     currBatchedMessage.writeInt32BE(self.numMessages, 0);
-    self.cachedBuf.copy(currBatchedMessage, KAFKA_BATCH_PADDING_BYTES, KAFKA_BATCH_PADDING_BYTES, self.currOffset);
+    self.cachedBuf.copy(currBatchedMessage, KAFKA_PADDINGS.BATCH_PADDING_BYTES,
+        KAFKA_PADDINGS.BATCH_PADDING_BYTES, self.currOffset);
 
     return currBatchedMessage;
 };
@@ -113,9 +124,9 @@ MessageBatch.prototype.getPendingCallbacks = function getPendingCallbacks() {
 MessageBatch.prototype.resetBatchedMessage = function resetBatchedMessage() {
     var self = this;
 
-    self.currOffset = KAFKA_BATCH_PADDING_BYTES;
+    self.currOffset = KAFKA_PADDINGS.BATCH_PADDING_BYTES;
     self.numMessages = 0;
-    self.sizeBytes = KAFKA_BATCH_PADDING_BYTES;
+    self.sizeBytes = KAFKA_PADDINGS.BATCH_PADDING_BYTES;
     self.pendingCallbacks = [];
 };
 

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -42,23 +42,8 @@ function MessageBatch(size) {
     self.pendingCallbacks = [];
 }
 
-MessageBatch.prototype._throwErrorIfNoCallback = function _throwErrorIfNoCallback(errorMessage, callback) {
-    var err = new Error(errorMessage);
-    if (!callback) {
-        throw err;
-    }
-    callback(err);
-};
-
 MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message, callback) {
     var self = this;
-
-    if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
-        // Not sure what this object is
-        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
-        return null;
-    }
-
     // No single message can be a batch by itself unless it is smaller
     // than our buffer size
     return message.length + KAFKA_PADDINGS.BATCH_PADDING_BYTES +
@@ -67,13 +52,6 @@ MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(me
 
 MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message, callback) {
     var self = this;
-
-    if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
-        // Not sure what this object is
-        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
-        return null;
-    }
-
     return self.sizeBytes + KAFKA_PADDINGS.MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
 };
 
@@ -91,7 +69,11 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         message.copy(self.cachedBuf, msgOffset);
         bytesWritten += message.length;
     } else {
-        self._throwErrorIfNoCallback('For batching, message must be a string or buffer, not ' + (typeof message), callback);
+        var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
+        if (!callback) {
+            throw err;
+        }
+        callback(err);
         return;
     }
 

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -42,7 +42,7 @@ function MessageBatch(size) {
     self.pendingCallbacks = [];
 }
 
-MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message, callback) {
+MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(message) {
     var self = this;
     // No single message can be a batch by itself unless it is smaller
     // than our buffer size
@@ -50,9 +50,9 @@ MessageBatch.prototype.exceedsBatchSizeBytes = function exceedsBatchSizeBytes(me
         KAFKA_PADDINGS.MESSAGE_PADDING_BYTES > self.maxBufferSize;
 };
 
-MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message, callback) {
+MessageBatch.prototype.canAddMessageToBatch = function canAddMessageToBatch(message) {
     var self = this;
-    return self.sizeBytes + KAFKA_PADDINGS.MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
+    return self.currOffset + KAFKA_PADDINGS.MESSAGE_PADDING_BYTES + message.length < self.maxBufferSize;
 };
 
 MessageBatch.prototype.addMessage = function addMessage(message, callback) {

--- a/lib/message_batch.js
+++ b/lib/message_batch.js
@@ -72,7 +72,7 @@ MessageBatch.prototype.addMessage = function addMessage(message, callback) {
         var err = new Error('For batching, message must be a string or buffer, not ' + (typeof message));
         if (callback) {
             callback(err);
-        }
+        } // TODO: else { self.logger.error(err); }
         return;
     }
 


### PR DESCRIPTION
Add helper methods to properly calculate full size of a single message when it's being sent as a batch. Fixes a bug where messages of length greater than `(producer.maxBatchSizeBytes - 8)` and `producer.maxBatchSizeBytes` would end up getting truncated because of offsets in the message Buffer.