### PR TITLE
Don't let timeStamp be null

### DIFF
--- a/lib/kafka_producer.js
+++ b/lib/kafka_producer.js
@@ -331,7 +331,7 @@ KafkaProducer.prototype.getProduceMessage = function getProduceMessage(topic, me
     var produceMessage = {};
     produceMessage.topic = topic;
     produceMessage.message = message;
-    produceMessage.timeStamp = timeStamp;
+    produceMessage.timeStamp = timeStamp || Date.now();
     produceMessage.type = type;
     return produceMessage;
 };


### PR DESCRIPTION
Causes some sadness when timeStamp is not being explicitly passed in AND we are trying to batch produce explicitly within the `produce` flow. We do not fallback to `Date.now()` in this flow like the `flushEntireCache` function is.