### PR TITLE
add lineage header support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,7 @@
         "setTimeout": true,
         "clearTimeout": true,
         "setInterval": true,
-        "clearInterval": true
+        "clearInterval": true,
+        "process": true
     }
 }

--- a/index.js
+++ b/index.js
@@ -23,3 +23,4 @@
 module.exports = require('./lib/kafka_producer');
 module.exports.KafkaDataProducer = require('./lib/kafka_data_producer');
 module.exports.ProducerRecord = require('./lib/producer_record');
+module.exports.version = require('./package.json').version;

--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -25,6 +25,7 @@ var url = require('url');
 var http = require('http');
 var lbPool = require('lb_pool');
 var os = require('os');
+var utils = require('./utils')
 
 var supportContentType = {
     'binary': 'application/vnd.kafka.binary.v1',
@@ -35,8 +36,8 @@ var supportContentType = {
 var emptyFunction = function EmptyFunction() {
 };
 
-var DEFAULT_APP_ENV_NAME = 'UDEPLOY_APP_ID';
-var DEFAULT_LINEAGE_HEADER = 'x-uber-source';
+var defaultAppNameEnvVar = 'UDEPLOY_APP_ID';
+var defaultLineageHeaderName = 'x-uber-source';
 
 var defaultLocalAgentHost = 'localhost';
 var defaultLocalAgentPort = 5390;
@@ -51,14 +52,6 @@ var defaultReconnectRetryMs = 100;
 String.isNullOrEmpty = function checkNullOrEmpty(value) {
     return !value;  // based on https://codereview.stackexchange.com/questions/5572/string-isnullorempty-in-javascript
 };
-
-// Retrieves some meaningful application name for data lineage
-function getApplicationName() {
-    var hostname = os.hostname();
-    var processName = process.argv[1];
-    var pid = process.pid;
-    return hostname + ',' + processName + ',' + pid;
-}
 // Kafka 8 Rest Proxy Client.
 // Initialization: takes host and port and send a GET call to get all the
 // <topic, host:port> mapping.
@@ -144,21 +137,21 @@ KafkaRestClient.prototype.initLineageOption = function initLineageOption(options
         if ('applicationNameEnv' in options) {
             self.applicationNameEnv = options.applicationNameEnv;
         }else {
-            self.applicationNameEnv = DEFAULT_APP_ENV_NAME; // the Uber default app id
+            self.applicationNameEnv = defaultAppNameEnvVar; // the Uber default app id
         }
         /* eslint-disable no-process-env */
         self.applicationName = process.env[self.applicationNameEnv];
         /* eslint-enable no-process-env */
 
         if (String.isNullOrEmpty(self.applicationName)) {
-            self.applicationName = getApplicationName();
+            self.applicationName = utils.getApplicationName();
         }
     }
 
     if ('lineageHeader' in options) {
         self.lineageHeader = options.lineageHeader;
     }else {
-        self.lineageHeader = DEFAULT_LINEAGE_HEADER;
+        self.lineageHeader = defaultLineageHeaderName;
     }
 
 };
@@ -358,9 +351,6 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
     }
     httpClient = self.urlToHttpClientMapping[pathUrl];
 
-    // http post call
-    // console.log('Trying to produce msg: ' + message + ',to topic: ' +
-    // topic + ', through url: ' + pathUrl);
     var reqOpts = url.parse('http://' + pathUrl);
     reqOpts.method = 'POST';
     reqOpts.path = '/topics/' + produceMessage.topic;

--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -26,6 +26,7 @@ var http = require('http');
 var lbPool = require('lb_pool');
 var os = require('os');
 var utils = require('./utils')
+var pkginfo = require('pkginfo')(module);
 
 var supportContentType = {
     'binary': 'application/vnd.kafka.binary.v1',
@@ -38,6 +39,7 @@ var emptyFunction = function EmptyFunction() {
 
 var defaultAppNameEnvVar = 'UDEPLOY_APP_ID';
 var defaultLineageHeaderName = 'x-uber-source';
+var defaultClientVersionHeader = 'client-version';
 
 var defaultLocalAgentHost = 'localhost';
 var defaultLocalAgentPort = 5390;
@@ -111,7 +113,7 @@ KafkaRestClient.prototype.initHttpClient = function initHttpClient(options) {
             /*jshint camelcase: true */
             /* eslint-enable camelcase */
         });
-    }else {
+    } else {
         self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl], {
             /* eslint-disable camelcase */
             /*jshint camelcase: false */
@@ -124,7 +126,7 @@ KafkaRestClient.prototype.initHttpClient = function initHttpClient(options) {
 
     if ('blacklistMigratorHttpClient' in options) {
         self.blacklistMigratorHttpClient = options.blacklistMigratorHttpClient;
-    }else {
+    } else {
         self.blacklistMigratorHttpClient = null;
     }
 };
@@ -133,10 +135,10 @@ KafkaRestClient.prototype.initLineageOption = function initLineageOption(options
     var self = this;
     if ('applicationName' in options) {
         self.applicationName = options.applicationName; // the application name for data lineage
-    }else {
+    } else {
         if ('applicationNameEnv' in options) {
             self.applicationNameEnv = options.applicationNameEnv;
-        }else {
+        } else {
             self.applicationNameEnv = defaultAppNameEnvVar; // the Uber default app id
         }
         /* eslint-disable no-process-env */
@@ -150,9 +152,16 @@ KafkaRestClient.prototype.initLineageOption = function initLineageOption(options
 
     if ('lineageHeader' in options) {
         self.lineageHeader = options.lineageHeader;
-    }else {
+    } else {
         self.lineageHeader = defaultLineageHeaderName;
     }
+
+    if ('clientVersionHeader' in options) {
+        self.clientVersionHeader = options.clientVersionHeader;
+    } else {
+        self.clientVersionHeader = defaultClientVersionHeader;
+    }
+    self.clientVersion = '[node,' + module.version + ']';
 
 };
 // produceInterval is for test purpose
@@ -365,6 +374,7 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
         reqOpts.headers['Request-Type'] = 'sync';
     }
     reqOpts.headers[self.lineageHeader] = self.applicationName;
+    reqOpts.headers[self.clientVersionHeader] = self.clientVersion;
 
     var time = new Date();
     httpClient.post(reqOpts, produceMessage.message, function handlePostCall(err, res, body) {

--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -38,8 +38,10 @@ var emptyFunction = function EmptyFunction() {
 };
 
 var defaultAppNameEnvVar = 'UDEPLOY_APP_ID';
-var defaultLineageHeaderName = 'x-uber-source';
-var defaultClientVersionHeader = 'client-version';
+var defaultServiceNameHeader = 'kafka-rest-client-service-name';
+var defaultVersionHeader = 'kafka-rest-client-version';
+var defaultInstanceNameHeader = 'kafka-rest-client-instance-name';
+var defaultInstanceNameEnvVar = 'UDEPLOY_DEPLOYMENT_NAME';
 
 var defaultLocalAgentHost = 'localhost';
 var defaultLocalAgentPort = 5390;
@@ -133,33 +135,55 @@ KafkaRestClient.prototype.initHttpClient = function initHttpClient(options) {
 
 KafkaRestClient.prototype.initLineageOption = function initLineageOption(options) {
     var self = this;
-    if ('applicationName' in options) {
-        self.applicationName = options.applicationName; // the application name for data lineage
+    if ('serviceName' in options) {
+        self.serviceName = options.serviceName; // the application name for data lineage
     } else {
-        if ('applicationNameEnv' in options) {
-            self.applicationNameEnv = options.applicationNameEnv;
+        if ('serviceNameEnv' in options) {
+            self.serviceNameEnv = options.serviceNameEnv;
         } else {
-            self.applicationNameEnv = defaultAppNameEnvVar; // the Uber default app id
+            self.serviceNameEnv = defaultAppNameEnvVar; // the Uber default app id
         }
         /* eslint-disable no-process-env */
-        self.applicationName = process.env[self.applicationNameEnv];
+        self.serviceName = process.env[self.serviceNameEnv];
         /* eslint-enable no-process-env */
 
-        if (String.isNullOrEmpty(self.applicationName)) {
-            self.applicationName = utils.getApplicationName();
+        if (String.isNullOrEmpty(self.serviceName)) {
+            self.serviceName = utils.getServiceName();
         }
     }
 
-    if ('lineageHeader' in options) {
-        self.lineageHeader = options.lineageHeader;
+    if ('serviceNameHeader' in options) {
+        self.serviceNameHeader = options.serviceNameHeader;
     } else {
-        self.lineageHeader = defaultLineageHeaderName;
+        self.serviceNameHeader = defaultServiceNameHeader;
     }
 
     if ('clientVersionHeader' in options) {
         self.clientVersionHeader = options.clientVersionHeader;
     } else {
-        self.clientVersionHeader = defaultClientVersionHeader;
+        self.clientVersionHeader = defaultVersionHeader;
+    }
+
+    if ('instanceNameHeader' in options) {
+        self.instanceNameHeader = options.instanceNameHeader;
+    } else {
+        self.instanceNameHeader = defaultInstanceNameHeader;
+    }
+
+    if ('instanceName' in options) {
+        self.instanceName = options.instanceName;
+    } else {
+        if ('instanceNameEnv' in options) {
+            self.instanceNameEnv = options.instanceNameEnv;
+        } else {
+            self.instanceNameEnv = defaultInstanceNameEnvVar;
+        }
+        /* eslint-disable no-process-env */
+        self.instanceName = process.env[this.instanceNameEnv];
+        if (String.isNullOrEmpty(self.instanceName)) {
+            self.instanceName = utils.getLimitedLength(os.hostname());
+        }
+        /* eslint-enable no-process-env */
     }
     self.clientVersion = '[node,' + module.version + ']';
 
@@ -373,8 +397,9 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
     if (self.clientType === 'AtLeastOnce') {
         reqOpts.headers['Request-Type'] = 'sync';
     }
-    reqOpts.headers[self.lineageHeader] = self.applicationName;
+    reqOpts.headers[self.serviceNameHeader] = self.serviceName;
     reqOpts.headers[self.clientVersionHeader] = self.clientVersion;
+    reqOpts.headers[self.instanceNameHeader] = self.instanceName;
 
     var time = new Date();
     httpClient.post(reqOpts, produceMessage.message, function handlePostCall(err, res, body) {

--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 'use strict';
+/* global process */
 
 var url = require('url');
 var http = require('http');
@@ -34,6 +35,9 @@ var supportContentType = {
 var emptyFunction = function EmptyFunction() {
 };
 
+var DEFAULT_APP_ENV_NAME = 'UDEPLOY_APP_ID';
+var DEFAULT_LINEAGE_HEADER = 'x-uber-source';
+
 var defaultLocalAgentHost = 'localhost';
 var defaultLocalAgentPort = 5390;
 var defaultClusterUrl = 'LOGGING TOPICS';
@@ -44,6 +48,17 @@ var totalWaitingTimeMs = 0;
 var connectWaitTimeMs = [0, 100, 3000, 10000, 30000, 60000, 300000, 600000];
 var defaultReconnectRetryMs = 100;
 
+String.isNullOrEmpty = function checkNullOrEmpty(value) {
+    return !value;  // based on https://codereview.stackexchange.com/questions/5572/string-isnullorempty-in-javascript
+};
+
+// Retrieves some meaningful application name for data lineage
+function getApplicationName() {
+    var hostname = os.hostname();
+    var processName = process.argv[1];
+    var pid = process.pid;
+    return hostname + ',' + processName + ',' + pid;
+}
 // Kafka 8 Rest Proxy Client.
 // Initialization: takes host and port and send a GET call to get all the
 // <topic, host:port> mapping.
@@ -61,38 +76,14 @@ function KafkaRestClient(options, callback) {
     self.urlToHttpClientMapping = {};
     self.cachedTopicToUrlMapping = {};
     self.proxyPort = options.proxyPort;
+    self.initLineageOption(options);
     self.requestUrl = self.proxyHost + ':' + self.proxyPort;
     self.metadataWhitelist = null;
     if ('metadataWhitelist' in options) {
         self.metadataWhitelist = options.metadataWhitelist;
     }
 
-    if (self.clientType === 'AtLeastOnce') {
-        self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl], {
-            /* eslint-disable camelcase */
-            /*jshint camelcase: false */
-            keep_alive: true,
-            timeout: self.timeout,
-            max_pending: self.maxPending
-            /*jshint camelcase: true */
-            /* eslint-enable camelcase */
-        });
-    } else {
-        self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl], {
-            /* eslint-disable camelcase */
-            /*jshint camelcase: false */
-            keep_alive: true
-            /*jshint camelcase: true */
-            /* eslint-enable camelcase */
-        });
-    }
-    self.proxyRefreshTime = options.refreshTime;
-
-    if ('blacklistMigratorHttpClient' in options) {
-        self.blacklistMigratorHttpClient = options.blacklistMigratorHttpClient;
-    } else {
-        self.blacklistMigratorHttpClient = null;
-    }
+    self.initHttpClient(options);
     self.topicDiscoveryTimes = 0;
     self.maxRetries = options.maxRetries || 3;
 
@@ -115,6 +106,62 @@ function KafkaRestClient(options, callback) {
     self.produceInterval = options.produceInterval || -1;
 }
 
+KafkaRestClient.prototype.initHttpClient = function initHttpClient(options) {
+    var self = this;
+    if (self.clientType === 'AtLeastOnce') {
+        self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl], {
+            /* eslint-disable camelcase */
+            /*jshint camelcase: false */
+            keep_alive: true,
+            timeout: self.timeout,
+            max_pending: self.maxPending
+            /*jshint camelcase: true */
+            /* eslint-enable camelcase */
+        });
+    }else {
+        self.mainHttpClient = new lbPool.Pool(http, [self.requestUrl], {
+            /* eslint-disable camelcase */
+            /*jshint camelcase: false */
+            keep_alive: true
+            /*jshint camelcase: true */
+            /* eslint-enable camelcase */
+        });
+    }
+    self.proxyRefreshTime = options.refreshTime;
+
+    if ('blacklistMigratorHttpClient' in options) {
+        self.blacklistMigratorHttpClient = options.blacklistMigratorHttpClient;
+    }else {
+        self.blacklistMigratorHttpClient = null;
+    }
+};
+
+KafkaRestClient.prototype.initLineageOption = function initLineageOption(options) {
+    var self = this;
+    if ('applicationName' in options) {
+        self.applicationName = options.applicationName; // the application name for data lineage
+    }else {
+        if ('applicationNameEnv' in options) {
+            self.applicationNameEnv = options.applicationNameEnv;
+        }else {
+            self.applicationNameEnv = DEFAULT_APP_ENV_NAME; // the Uber default app id
+        }
+        /* eslint-disable no-process-env */
+        self.applicationName = process.env[self.applicationNameEnv];
+        /* eslint-enable no-process-env */
+
+        if (String.isNullOrEmpty(self.applicationName)) {
+            self.applicationName = getApplicationName();
+        }
+    }
+
+    if ('lineageHeader' in options) {
+        self.lineageHeader = options.lineageHeader;
+    }else {
+        self.lineageHeader = DEFAULT_LINEAGE_HEADER;
+    }
+
+};
 // produceInterval is for test purpose
 // In production env, the interval is exponential back-off as 600 * Math.pow(5, retry + 1)
 KafkaRestClient.prototype.getProduceInterval = function getProduceInterval(retry) {
@@ -186,7 +233,7 @@ KafkaRestClient.prototype.getTopicRequestBody = function getTopicRequestBody(pro
     var self = this;
     var endpoint = '/topics';
     if (self.metadataWhitelist !== null) {
-        endpoint += "?topics=" + self.metadataWhitelist.join();
+        endpoint += '?topics=' + self.metadataWhitelist.join();
     }
     self.mainHttpClient.get(endpoint, function handleGetCall(err, res, body) {
         if (err) {
@@ -327,6 +374,8 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
     if (self.clientType === 'AtLeastOnce') {
         reqOpts.headers['Request-Type'] = 'sync';
     }
+    reqOpts.headers[self.lineageHeader] = self.applicationName;
+
     var time = new Date();
     httpClient.post(reqOpts, produceMessage.message, function handlePostCall(err, res, body) {
         var metricPrefix = self.metricsPrefix + produceMessage.topic;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var os = require('os');
+
+/* global process */
+
+var clientIDMaxBlockLength = 128;
+
+
+// Retrieves some meaningful application name for data lineage
+function getApplicationName() {
+    var hostname = os.hostname();
+    var processName = process.argv[1];
+    var pid = process.pid;
+    return getLimitedLength(hostname, processName, pid);
+}
+
+// Limits our application name with
+function getLimitedLength(hostname, processName, pid) {
+    if (hostname.length > clientIDMaxBlockLength){
+        hostname = hostname.substring(0, length - 1);
+    }
+    if (processName.length > clientIDMaxBlockLength){
+        processName = processName.substring(processName.length - clientIDMaxBlockLength, processName.length);
+    }
+    return '[' + hostname + ',' + processName + ',' + pid + ']';
+
+}
+
+module.exports = {
+    getApplicationName: getApplicationName,
+    getLimitedLength: getLimitedLength
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,7 @@ function getApplicationName() {
 // Limits our application name with
 function getLimitedLength(hostname, processName, pid) {
     if (hostname.length > clientIDMaxBlockLength){
-        hostname = hostname.substring(0, length - 1);
+        hostname = hostname.substring(0, clientIDMaxBlockLength - 1);
     }
     if (processName.length > clientIDMaxBlockLength){
         processName = processName.substring(processName.length - clientIDMaxBlockLength, processName.length);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,34 +20,27 @@
 
 'use strict';
 
-var os = require('os');
-
 /* global process */
 
 var clientIDMaxBlockLength = 128;
 
 
 // Retrieves some meaningful application name for data lineage
-function getApplicationName() {
-    var hostname = os.hostname();
+function getServiceName() {
     var processName = process.argv[1];
     var pid = process.pid;
-    return getLimitedLength(hostname, processName, pid);
+    return '[' + getLimitedLength(processName) + ',' + pid + ']';
 }
 
-// Limits our application name with
-function getLimitedLength(hostname, processName, pid) {
-    if (hostname.length > clientIDMaxBlockLength){
-        hostname = hostname.substring(0, clientIDMaxBlockLength - 1);
-    }
-    if (processName.length > clientIDMaxBlockLength){
-        processName = processName.substring(processName.length - clientIDMaxBlockLength, processName.length);
-    }
-    return '[' + hostname + ',' + processName + ',' + pid + ']';
 
+function getLimitedLength(longName) {
+    if (longName.length > clientIDMaxBlockLength) {
+        longName = longName.substring(0, clientIDMaxBlockLength - 1);
+    }
+    return longName;
 }
 
 module.exports = {
-    getApplicationName: getApplicationName,
+    getServiceName: getServiceName,
     getLimitedLength: getLimitedLength
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "./index.js",
   "dependencies": {
     "error": "^7.0.1",
-    "lb_pool": "^1.2.0"
+    "lb_pool": "^1.2.0",
+    "pkginfo": "^0.4.1"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/test/test_kafka_data_producer.js
+++ b/test/test_kafka_data_producer.js
@@ -85,7 +85,8 @@ test('Kafka producer could write with produce.', function testKafkaProducer(asse
                 producer.produceSync('testTopic0', new ProducerRecord({value: 'value'}), generateSuccessCheck(next));
             },
             function testWithKeyAndValue(next) {
-                producer.produceSync('testTopic1', new ProducerRecord({key: 'test_key', value: 'value'}), generateSuccessCheckWithKey(next));
+                producer.produceSync('testTopic1', new ProducerRecord({key: 'test_key', value: 'value'}),
+                    generateSuccessCheckWithKey(next));
             },
             function testWithoutValue(next) {
                 producer.produceSync('testTopic10', new ProducerRecord({key: 'test_key'}), generateErrorCheck(next));

--- a/test/test_kafka_rest_client.js
+++ b/test/test_kafka_rest_client.js
@@ -221,23 +221,29 @@ function verifyHeader(assert, PORT, restClient) {
     var topicName = "LOGGING TOPICS";
     var timeStamp = Date.now() / 1000.0;
 
-    function OverriddenHttpClient(expectedHeader, expectedAppName, expectedClientVersionHeader){
-        this.expectedHeader = expectedHeader;
-        this.expectedAppName = expectedAppName;
+    function OverriddenHttpClient(expectedServiceNameHeader, expectedServiceName, expectedClientVersionHeader,
+                                  expectedInstanceNameHeader, expectedInstanceName){
+        this.expectedServiceNameHeader = expectedServiceNameHeader;
+        this.expectedServiceName = expectedServiceName;
         this.postMethodCalled = false;
         this.expectedClientVersionHeader = expectedClientVersionHeader;
+        this.expectedInstanceNameHeader = expectedInstanceNameHeader;
+        this.expectedInstanceName = expectedInstanceName;
     }
 
     OverriddenHttpClient.prototype.post = function post(reqOpts, msg, cb){
-        assert.true(this.expectedHeader in reqOpts.headers);
-        assert.equal(reqOpts.headers[this.expectedHeader], this.expectedAppName);
+        assert.true(this.expectedServiceNameHeader in reqOpts.headers);
+        assert.true(this.expectedInstanceNameHeader in reqOpts.headers);
+        assert.equal(reqOpts.headers[this.expectedServiceNameHeader], this.expectedServiceName);
+        assert.equal(reqOpts.headers[this.expectedInstanceNameHeader], this.expectedInstanceName);
         assert.true(reqOpts.headers[this.expectedClientVersionHeader].indexOf('node') >= 0);
         this.postMethodCalled = true;
         //cb();
     };
 
-    var mockedHttpClient = new OverriddenHttpClient(restClient.lineageHeader,
-        restClient.applicationName, restClient.clientVersionHeader);
+    var mockedHttpClient = new OverriddenHttpClient(restClient.serviceNameHeader,
+        restClient.serviceName, restClient.clientVersionHeader, restClient.instanceNameHeader,
+        restClient.instanceName);
     var urlPath = "localhost:" + PORT.toString();
     restClient.urlToHttpClientMapping = {};
     restClient.urlToHttpClientMapping[urlPath] = mockedHttpClient;
@@ -260,83 +266,109 @@ test('KafkaRestClient can apply lineage header config correctly', function testK
     /* global process */
     /* eslint-disable no-process-env */
 
-    // case 1: pass in applicationName directly. use it
+    // case 1: pass in serviceName directly. use it
     process.env.UDEPLOY_APP_ID = 'Pickle!';
+    process.env.UDEPLOY_DEPLOYMENT_NAME = 'Beth';
     var restClient = new KafkaRestClient({
         proxyHost: configs.proxyHost,
         proxyPort: configs.proxyPort,
         refreshTime: configs.proxyRefreshTime,
         maxRetries: 3,
-        applicationName: 'Rick and Morty'
+        serviceName: 'Rick and Morty',
+        instanceName: 'production #4'
     });
-    assert.equal(restClient.lineageHeader, 'x-uber-source');
-    assert.equal(restClient.applicationName, 'Rick and Morty');
+    assert.equal(restClient.serviceNameHeader, 'kafka-rest-client-service-name');
+    assert.equal(restClient.serviceName, 'Rick and Morty');
+    assert.equal(restClient.instanceName, 'production #4');
+    assert.true(restClient.clientVersion.indexOf('node') > -1);
     verifyHeader(assert, PORT, restClient);
 
     // case 2: pass in nothing, and no environment var,
-    //  result: generate default with client version and hostname
+    //  result: generate default with client version, service name, and instance name
     process.env.UDEPLOY_APP_ID = '';
+    process.env.UDEPLOY_DEPLOYMENT_NAME = '';
     var restClient2 = new KafkaRestClient({
         proxyHost: configs.proxyHost,
         proxyPort: configs.proxyPort,
         refreshTime: configs.proxyRefreshTime,
         maxRetries: 3
     });
-    assert.equal(restClient2.lineageHeader, 'x-uber-source');
-    assert.equal(restClient2.applicationNameEnv, 'UDEPLOY_APP_ID');
-    assert.assert(restClient2.applicationName.indexOf('node-kafka-rest-client') > -1);
-    assert.assert(restClient2.applicationName.indexOf(os.hostname()) > -1);
+    assert.equal(restClient2.serviceNameHeader, 'kafka-rest-client-service-name');
+    assert.equal(restClient2.serviceNameEnv, 'UDEPLOY_APP_ID');
+    assert.assert(restClient2.serviceName.indexOf('node-kafka-rest-client') > -1);
+    assert.assert(restClient2.instanceName.indexOf(os.hostname()) > -1);
+    assert.true(restClient2.clientVersion.indexOf('node') > -1);
     verifyHeader(assert, PORT, restClient2);
 
     // case 3: pass in nothing, but environment var has value,
     //  result: generate name by environment variable value
     process.env.UDEPLOY_APP_ID = 'Pickle!';
+    process.env.UDEPLOY_DEPLOYMENT_NAME = 'Planet-Express';
     var restClient3 = new KafkaRestClient({
         proxyHost: configs.proxyHost,
         proxyPort: configs.proxyPort,
         refreshTime: configs.proxyRefreshTime,
         maxRetries: 3
     });
-    assert.equal(restClient3.lineageHeader, 'x-uber-source');
-    assert.equal(restClient3.applicationNameEnv, 'UDEPLOY_APP_ID');
-    assert.equal(restClient3.applicationName, 'Pickle!');
+    assert.equal(restClient3.serviceNameHeader, 'kafka-rest-client-service-name');
+    assert.equal(restClient3.serviceNameEnv, 'UDEPLOY_APP_ID');
+    assert.equal(restClient3.instanceNameEnv, 'UDEPLOY_DEPLOYMENT_NAME');
+    assert.equal(restClient3.serviceName, 'Pickle!');
+    assert.assert(restClient3.instanceName, 'Planet-Express');
+    assert.true(restClient3.clientVersion.indexOf('node') > -1);
+
     verifyHeader(assert, PORT, restClient3);
 
     // case 4: pass in customized environment variable name, and customize header name
     //  result: generate name by customized environment variable value with new header
     process.env.UDEPLOY_APP_ID = 'Pickle!';
     process.env.RICK_APP_ID = 'Meeseek';
+    process.env.UDEPLOY_DEPLOYMENT_NAME = 'Planet-Express';
+    process.env.MORTY_INSTANCE_ID = 'Citadel';
     var restClient4 = new KafkaRestClient({
         proxyHost: configs.proxyHost,
         proxyPort: configs.proxyPort,
         refreshTime: configs.proxyRefreshTime,
         maxRetries: 3,
-        applicationNameEnv: 'RICK_APP_ID',
-        lineageHeader: 'lineage-source'
+        serviceNameEnv: 'RICK_APP_ID',
+        serviceNameHeader: 'lineage-source',
+        instanceNameEnv: 'MORTY_INSTANCE_ID',
+        instanceNameHeader: 'ricklantis-mixup'
     });
-    assert.equal(restClient4.lineageHeader, 'lineage-source');
-    assert.equal(restClient4.applicationNameEnv, 'RICK_APP_ID');
-    assert.equal(restClient4.applicationName, 'Meeseek');
+    assert.equal(restClient4.serviceNameHeader, 'lineage-source');
+    assert.equal(restClient4.serviceNameEnv, 'RICK_APP_ID');
+    assert.equal(restClient4.serviceName, 'Meeseek');
+    assert.equal(restClient4.instanceNameEnv, 'MORTY_INSTANCE_ID');
+    assert.equal(restClient4.instanceNameHeader, 'ricklantis-mixup');
+    assert.equal(restClient4.instanceName, 'Citadel');
+    assert.true(restClient4.clientVersion.indexOf('node') > -1);
 
     verifyHeader(assert, PORT, restClient4);
 
-    // case 5: pass in customized environment variable name, and customize header name
-    //  result: generate name by customized environment variable value with new header
+    // case 5: pass in everything in config
+    //  result: the instance name and service name provided is used
     process.env.UDEPLOY_APP_ID = 'Pickle!';
     process.env.RICK_APP_ID = 'Meeseek';
+    process.env.UDEPLOY_DEPLOYMENT_NAME = 'Planet-Express';
+    process.env.MORTY_INSTANCE_ID = 'Citadel';
     var restClient5 = new KafkaRestClient({
         proxyHost: configs.proxyHost,
         proxyPort: configs.proxyPort,
         refreshTime: configs.proxyRefreshTime,
         maxRetries: 3,
-        applicationNameEnv: 'RICK_APP_ID',
-        lineageHeader: 'lineage-source',
+        serviceName: 'Meeseek',
+        serviceNameEnv: 'RICK_APP_ID',
+        serviceNameHeader: 'lineage-source',
+        instanceName: 'production #1',
+        instanceNameHeader: 'ricklantis-mixup',
         clientVersionHeader: 'x-client-id'
     });
-    assert.equal(restClient5.lineageHeader, 'lineage-source');
-    assert.equal(restClient5.applicationNameEnv, 'RICK_APP_ID');
-    assert.equal(restClient5.applicationName, 'Meeseek');
+    assert.equal(restClient5.serviceNameHeader, 'lineage-source');
+    assert.equal(restClient5.serviceName, 'Meeseek');
+    assert.equal(restClient5.instanceNameHeader, 'ricklantis-mixup');
+    assert.equal(restClient5.instanceName, 'production #1');
     assert.equal(restClient5.clientVersionHeader, 'x-client-id');
+    assert.true(restClient5.clientVersion.indexOf('node') > -1);
 
     verifyHeader(assert, PORT, restClient5);
     assert.end();

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -24,35 +24,19 @@ var test = require('tape');
 var utils = require('../lib/utils');
 
 test('getHostName can get meaningful results', function testGetHostName(assert) { // eslint-disable-line
-    var appName = utils.getApplicationName();
+    var appName = utils.getServiceName();
     assert.true(appName.length >= 1);
 });
 
 test('getLimitedLength can limit hostname length', function testGetLimitedLength(assert) { // eslint-disable-line
 
-    var appNameSimple = utils.getLimitedLength('zoidberg_pc', 'kafka_rest_client.js', 46);
-    assert.true(appNameSimple.indexOf('zoidberg_pc') >= 0);
-    assert.true(appNameSimple.indexOf('kafka_rest_client.js') >= 0);
-    assert.true(appNameSimple.indexOf('46') >= 0);
-
     var longHostName = 'a_very_long_host_name_01234567890abcdef_01234567890abcdef' +
         '01234567890abcdef_01234567890abcdef' + '01234567890abcdef_01234567890abcdef' +
         '01234567890abcdef_01234567890abcdef';
-    var appNameTruncatedHost = utils.getLimitedLength(longHostName, 'kafka_rest_client.js', 46);
+    var appNameTruncatedHost = utils.getLimitedLength(longHostName);
     assert.true(appNameTruncatedHost.indexOf(longHostName) < 0);
     assert.true(appNameTruncatedHost.indexOf(longHostName.substr(0, 24)) >= 0);
-    assert.true(appNameTruncatedHost.indexOf('kafka_rest_client.js') >= 0);
-    assert.true(appNameTruncatedHost.indexOf('46') >= 0);
 
-    var longProcessName = 'a_very_long_process_name_1234567890abcdef_01234567890abcdef' +
-        '01234567890abcdef_01234567890abcdef' + '01234567890abcdef_01234567890abcdef' +
-        '01234567890abcdef_01234567890abcdef';
-    var appNameTruncatedBoth = utils.getLimitedLength(longHostName, longProcessName, 46);
-    assert.true(appNameTruncatedBoth.indexOf(longHostName) < 0);
-    assert.true(appNameTruncatedBoth.indexOf(longHostName.substr(0, 24)) >= 0);
-    assert.true(appNameTruncatedBoth.indexOf(longProcessName) < 0);
-    assert.true(appNameTruncatedBoth.indexOf(longProcessName.substr(0, 24)) >= 0);
-    assert.true(appNameTruncatedBoth.indexOf('46') >= 0);
     assert.end();
 
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var utils = require('../lib/utils');
+
+test('getHostName can get meaningful results', function testGetHostName(assert) { // eslint-disable-line
+    var appName = utils.getApplicationName();
+    assert.true(appName.length >= 1);
+});
+
+test('getLimitedLength can limit hostname length', function testGetLimitedLength(assert) { // eslint-disable-line
+
+    var appNameSimple = utils.getLimitedLength('zoidberg_pc', 'kafka_rest_client.js', 46);
+    assert.true(appNameSimple.indexOf('zoidberg_pc') >= 0);
+    assert.true(appNameSimple.indexOf('kafka_rest_client.js') >= 0);
+    assert.true(appNameSimple.indexOf('46') >= 0);
+
+    var longHostName = 'a_very_long_host_name_01234567890abcdef_01234567890abcdef' +
+        '01234567890abcdef_01234567890abcdef' + '01234567890abcdef_01234567890abcdef' +
+        '01234567890abcdef_01234567890abcdef';
+    var appNameTruncatedHost = utils.getLimitedLength(longHostName, 'kafka_rest_client.js', 46);
+    assert.true(appNameTruncatedHost.indexOf(longHostName) < 0);
+    assert.true(appNameTruncatedHost.indexOf(longHostName.substr(0, 24)) >= 0);
+    assert.true(appNameTruncatedHost.indexOf('kafka_rest_client.js') >= 0);
+    assert.true(appNameTruncatedHost.indexOf('46') >= 0);
+
+    var longProcessName = 'a_very_long_process_name_1234567890abcdef_01234567890abcdef' +
+        '01234567890abcdef_01234567890abcdef' + '01234567890abcdef_01234567890abcdef' +
+        '01234567890abcdef_01234567890abcdef';
+    var appNameTruncatedBoth = utils.getLimitedLength(longHostName, longProcessName, 46);
+    assert.true(appNameTruncatedBoth.indexOf(longHostName) < 0);
+    assert.true(appNameTruncatedBoth.indexOf(longHostName.substr(0, 24)) >= 0);
+    assert.true(appNameTruncatedBoth.indexOf(longProcessName) < 0);
+    assert.true(appNameTruncatedBoth.indexOf(longProcessName.substr(0, 24)) >= 0);
+    assert.true(appNameTruncatedBoth.indexOf('46') >= 0);
+    assert.end();
+
+});


### PR DESCRIPTION
Added the capability to customize one extra header to track application name.

If nothing is configured, we will try to fetch from environment variable `UDEPLOY_APP_ID` value. If the UDEPLOY_APP_ID environment variable does not exist, we will try to generate a string by ${hostname},${nodemodule},${process_id}