### PR TITLE
Downgrade sinon and move to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,12 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "@sinonjs/formatio": "^2.0.0",
     "error": "^7.0.1",
     "lb_pool": "^1.7.1",
-    "pkginfo": "^0.4.1",
-    "sinon": "^4.5.0"
+    "pkginfo": "^0.4.1"
   },
   "devDependencies": {
+    "@sinonjs/formatio": "^2.0.0",
     "async": "^1.5.2",
     "buffertools": "*",
     "chai": "*",
@@ -31,7 +30,7 @@
     "proxyquire": "*",
     "rewire": "3.0.2",
     "should": "*",
-    "sinon": "*",
+    "sinon": "~1.7.3",
     "tape": "^4.2.0",
     "uber-licence": "^1.2.0",
     "uber-standard": "^5.1.0"


### PR DESCRIPTION
Moves sinon-related packages to devDependencies.

Additionally downgrades sinon to ~1.7.3 which is known to work with node v0.10.x services.