### PR TITLE
Pass through serviceName config

### DIFF
--- a/lib/kafka_base_producer.js
+++ b/lib/kafka_base_producer.js
@@ -54,6 +54,8 @@ function KafkaBaseProducer(options, producerType) { // eslint-disable-line
         self.proxyHost = options.proxyHost || 'localhost';
         self.proxyPort = options.proxyPort;
 
+        self.serviceName = options.serviceName;
+        
         self.maxRetries = options.maxRetries || 3;
         self.produceInterval = options.produceInterval || -1;
         self.localAgentPort = options.localAgentPort || defaultLocalAgentPort;
@@ -186,6 +188,7 @@ KafkaBaseProducer.prototype.connect = function connect(onConnect) {
     if (self.init) {
         var restClientOptions = {
             clientType: self.clientType,
+            serviceName: self.serviceName,
             proxyHost: self.proxyHost,
             proxyPort: self.proxyPort,
             localAgentPort: self.localAgentPort,


### PR DESCRIPTION
KafkaRestClient takes an explicit `serviceName` option but in no case is option this ever passed. This PR will pass through this option.