### PR TITLE
fix lint issue

### DIFF
--- a/lib/kafka_base_producer.js
+++ b/lib/kafka_base_producer.js
@@ -120,11 +120,11 @@ function KafkaBaseProducer(options, producerType) { // eslint-disable-line
 
             // flush a topic's batch message every second
             self.flushCycleSecs = options.flushCycleSecs || 1;
-            var flushCache = function flushCache() {
+            var cache = function flushCache() {
                 // eslint-disable-line
                 self.flushEntireCache();
             };
-            self.flushInterval = setInterval(flushCache, self.flushCycleSecs * 1000); // eslint-disable-line
+            self.flushInterval = setInterval(cache, self.flushCycleSecs * 1000); // eslint-disable-line
         }
 
         if (self.enableAudit) {


### PR DESCRIPTION
$ npm version patch
v1.11.2
npm ERR! Darwin 17.4.0
npm ERR! argv "node" "/Users/mingminchen/.nvm/v0.10.32/bin/npm" "version" "patch"
npm ERR! node v0.10.32
npm ERR! npm  v2.14.2
npm ERR! code 1

npm ERR! Command failed: Error: Use Uber JavaScript Standard Style (https://github.com/uber/standard)
npm ERR! /Users/mingminchen/Uber/kafka-client/node-kafka-rest-client/lib/kafka_base_producer.js
npm ERR!    123:38  flushCache is already declared in the upper scope. (no-shadow)
npm ERR!
npm ERR! pre-commit: You've failed to pass all the hooks.
npm ERR! pre-commit:
npm ERR! pre-commit: The "npm run lint" script failed.
npm ERR! pre-commit:
npm ERR! pre-commit: You can skip the git pre-commit hook by running:
npm ERR! pre-commit:
npm ERR! pre-commit:   git commit -n (--no-verify)
npm ERR! pre-commit:
npm ERR! pre-commit: But this is not adviced as your tests are obviously failing.
npm ERR!
npm ERR!
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/mingminchen/Uber/kafka-client/node-kafka-rest-client/npm-debug.log