### PR TITLE
Set keep_alive to false to fix memory leak

### DIFF
--- a/lib/kafka_rest_client.js
+++ b/lib/kafka_rest_client.js
@@ -371,7 +371,7 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
             self.urlToHttpClientMapping[pathUrl] = new lbPool.Pool(http, [pathUrl], {
                 /* eslint-disable camelcase */
                 /* jshint camelcase: false */
-                keep_alive: true,
+                keep_alive: false,
                 timeout: self.timeout,
                 max_pending: self.maxPending
                 /* jshint camelcase: true */
@@ -381,7 +381,7 @@ KafkaRestClient.prototype.tryMakeRequest = function tryMakeRequest(produceMessag
             self.urlToHttpClientMapping[pathUrl] = new lbPool.Pool(http, [pathUrl], {
                 /* eslint-disable camelcase */
                 /* jshint camelcase: false */
-                keep_alive: true
+                keep_alive: false,
                 /* jshint camelcase: true */
                 /* eslint-enable camelcase */
             });


### PR DESCRIPTION
Setting keep_alive to true causes a memory leak with modern versions of node. This updates the default to false.